### PR TITLE
Select de filtro y Revisar vacante

### DIFF
--- a/gipit-back/app/api/process/[id]/route.ts
+++ b/gipit-back/app/api/process/[id]/route.ts
@@ -259,7 +259,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     const updatedProcess = await prisma.process.update({
       where: { id: parseInt(id) },
       data: {
-        job_offer: data.job_offer,
+        job_offer: data.name,
         job_offer_description: data.job_offer_description,
         opened_at: data.opened_at ? new Date(data.opened_at) : undefined,
         closed_at: data.closed_at ? new Date(data.closed_at) : undefined,

--- a/gipit-back/prisma/schema.prisma
+++ b/gipit-back/prisma/schema.prisma
@@ -157,6 +157,7 @@ model users {
   role_id          Int
   is_active        Boolean            @default(true)
   comments_process comments_process[]
+  notifications    notifications[]
   roles            roles              @relation(fields: [role_id], references: [id], onUpdate: NoAction)
   users_company    users_company[]
   users_management users_management[]
@@ -201,4 +202,18 @@ model users_company {
   updated_at DateTime? @default(now()) @db.Timestamp(6)
   company    company?  @relation(fields: [company_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   users      users?    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+}
+
+model notifications {
+  id              Int       @id @default(autoincrement())
+  user_id         Int
+  type            String?   @db.VarChar(50)
+  title           String?   @db.VarChar(100)
+  message         String?
+  created_at      DateTime? @default(now()) @db.Timestamp(6)
+  expiration_date DateTime? @db.Timestamp(6)
+  is_read         Boolean?  @default(false)
+  url             String?   @db.VarChar(255)
+  priority        String?   @db.VarChar(10)
+  users           users     @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }


### PR DESCRIPTION
El select del filtro por compañía se oculta a los usuarios con rol "cliente" y "cliente-gerente".
Los clientes y cliente-gerentes ahora solo podrán ver la descripción de la vacante sin poder editarla.
Los administradores ahora pueden editar la información del proceso.